### PR TITLE
Prevent off-screen tooltips (issue #2) using bootstrap

### DIFF
--- a/css/achilles.css
+++ b/css/achilles.css
@@ -291,19 +291,19 @@ div.personSummary .row div {
 
 .pathleaf {
 	font-size: 14px;
-	color: #fff;
+	color: #333;
 	font-weight: bold;
 	margin-bottom: 3px;
 }
 .pathleafstat {
 	font-size: 12px;
-	color: #ddd;
+	color: #666;
 	font-family: "Courier New";
 	margin-bottom: 2px;
 }
 .pathstep {
 	font-size: 12px;
-	color: #aaa;
+	color: #333;
 	margin-bottom: 1px;
 }
 hr.path {
@@ -387,4 +387,8 @@ table.dataTable tbody tr.odd.selected {
 }
 .sorting_3 {
 	background-color: rgba(89, 159, 216, 0.1) !important;
+}
+.popover {
+	max-width: 800px;
+	z-index: 1040;
 }

--- a/js/app/reports/condition_era.js
+++ b/js/app/reports/condition_era.js
@@ -167,8 +167,7 @@
 						url: 'data/' + folder + '/conditionera_treemap.json',
 						contentType: "application/json; charset=utf-8",
 						success: function (data) {
-							var normalizedData = common.normalizeDataframe(data);
-							var table_data = normalizedData.CONCEPT_PATH.map(function (d, i) {
+							table_data = data.CONCEPT_PATH.map(function (d, i) {
 								conceptDetails = this.CONCEPT_PATH[i].split('||');
 								return {
 									concept_id: this.CONCEPT_ID[i],
@@ -242,23 +241,26 @@
 								getcolorvalue: function (node) {
 									return node.length_of_era;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Length of Era: ' + node.length_of_era  + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/condition_occurrence.js
+++ b/js/app/reports/condition_occurrence.js
@@ -169,8 +169,7 @@
 						url: 'data/' + folder + '/condition_treemap.json',
 						contentType: "application/json; charset=utf-8",
 						success: function (data) {
-							var normalizedData = common.normalizeDataframe(data);
-							var table_data = normalizedData.CONCEPT_PATH.map(function (d, i) {
+							table_data = data.CONCEPT_PATH.map(function (d, i) {
 								conceptDetails = this.CONCEPT_PATH[i].split('||');
 								return {
 									concept_id: this.CONCEPT_ID[i],
@@ -244,23 +243,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/drug_era.js
+++ b/js/app/reports/drug_era.js
@@ -170,8 +170,7 @@
 						url: 'data/' + folder + '/drugera_treemap.json',
 						contentType: "application/json; charset=utf-8",
 						success: function (data) {
-							var normalizedData = common.normalizeDataframe(data);
-							var table_data = normalizedData.CONCEPT_PATH.map(function (d, i) {
+							table_data = data.CONCEPT_PATH.map(function (d, i) {
 								conceptDetails = this.CONCEPT_PATH[i].split('||');
 								return {
 									concept_id: this.CONCEPT_ID[i],
@@ -240,23 +239,26 @@
 								getcolorvalue: function (node) {
 									return node.length_of_era;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/drug_exposure.js
+++ b/js/app/reports/drug_exposure.js
@@ -181,8 +181,7 @@
 						url: 'data/' + folder + '/drug_treemap.json',
 						contentType: "application/json; charset=utf-8",
 						success: function (data) {
-							var normalizedData = common.normalizeDataframe(data);
-							var table_data = normalizedData.CONCEPT_PATH.map(function (d, i) {
+							table_data = data.CONCEPT_PATH.map(function (d, i) {
 								conceptDetails = this.CONCEPT_PATH[i].split('||');
 								return {
 									concept_id: this.CONCEPT_ID[i],
@@ -256,23 +255,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/observation.js
+++ b/js/app/reports/observation.js
@@ -343,8 +343,7 @@
 						url: 'data/' + folder + '/observation_treemap.json',
 						contentType: "application/json; charset=utf-8",
 						success: function (data) {
-							var normalizedData = common.normalizeDataframe(data);
-							var table_data = normalizedData.CONCEPT_PATH.map(function (d, i) {
+							table_data = data.CONCEPT_PATH.map(function (d, i) {
 								conceptDetails = this.CONCEPT_PATH[i].split('||');
 								return {
 									concept_id: this.CONCEPT_ID[i],
@@ -413,23 +412,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/procedure_occurrence.js
+++ b/js/app/reports/procedure_occurrence.js
@@ -168,8 +168,7 @@
 						url: 'data/' + folder + '/procedure_treemap.json',
 						contentType: "application/json; charset=utf-8",
 						success: function (data) {
-							var normalizedData = common.normalizeDataframe(data);
-							var table_data = normalizedData.CONCEPT_PATH.map(function (d, i) {
+							table_data = data.CONCEPT_PATH.map(function (d, i) {
 								conceptDetails = this.CONCEPT_PATH[i].split('||');
 								return {
 									concept_id: this.CONCEPT_ID[i],
@@ -238,23 +237,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/visit_occurrence.js
+++ b/js/app/reports/visit_occurrence.js
@@ -180,8 +180,7 @@
 						contentType: "application/json; charset=utf-8",
 						success: function (data) {
 							data = common.normalizeDataframe(data);
-							var normalizedData = common.normalizeDataframe(data);
-							var table_data = normalizedData.CONCEPT_PATH.map(function (d, i) {
+							table_data = data.CONCEPT_PATH.map(function (d, i) {
 								conceptDetails = this.CONCEPT_PATH[i].split('||');
 								return {
 									concept_id: this.CONCEPT_ID[i],
@@ -237,23 +236,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/modules/d3/jnj.chart.js
+++ b/js/modules/d3/jnj.chart.js
@@ -1659,14 +1659,6 @@
 				.domain([color_range[0], color_range[1]])
 				.range(["#E4FF7A", "#FC7F00"]);
 
-			var tip = d3.tip()
-				.attr('class', 'd3-tip')
-				.offset([-10, 0])
-				.html(function (d) {
-					return options.gettitle(d);
-				})
-			svg.call(tip);
-
 			var cell = svg.selectAll("g")
 				.data(nodes)
 				.enter().append("svg:g")
@@ -1682,17 +1674,23 @@
 				.attr("height", function (d) {
 					return Math.max(0, d.dy - 1);
 				})
-				.attr("title", function (d) {
-					return options.gettitle(d);
-				})
 				.attr("id", function (d) {
 					return d.id;
 				})
 				.style("fill", function (d) {
 					return color(options.getcolorvalue(d));
 				})
-				.on('mouseover', tip.show)
-				.on('mouseout', tip.hide)
+				.attr("data-container", "body")
+				.attr("data-toggle", "popover")
+				.attr("data-trigger", "hover")
+				.attr("data-placement", "top")
+				.attr("data-html", true)
+				.attr("data-title", function (d) {
+					return options.gettitle(d);
+				})
+				.attr("data-content", function (d) {
+					return options.getcontent(d);
+				})
 				.on('click', function (d) {
 					if (d3.event.altKey) {
 						zoom(root);


### PR DESCRIPTION
I used bootstrap popovers instead of d3-tip to generate tooltips for all treemaps. I had to change some styles to make the text visible and to prevent the nav from overlapping. I'm not sure if this breaks anything- please review.
