### PR TITLE
Add commas to large numbers in AchillesHeel report

### DIFF
--- a/js/app/reports/achilles_heel.js
+++ b/js/app/reports/achilles_heel.js
@@ -17,6 +17,11 @@
 								message_type = temp.substring(0, temp.indexOf(':'));
 								message_content = temp.substring(temp.indexOf(':') + 1);
 
+								// RSD - A quick hack to put commas into large numbers.
+								// Found the regexp at:
+								// https://stackoverflow.com/questions/23104663/knockoutjs-format-numbers-with-commas
+								message_content = message_content.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
 								table_data[i] = {
 									'type': message_type,
 									'content': message_content


### PR DESCRIPTION
I quickly hacked in a regexp to put commas in large numbers.
Unfortunately, it puts commas in the error report numbers too.
We'd probably be better off formatting the numbers in Achilles
itself, but that's a problem I'm not prepared to tackle.