### PR TITLE
Prevent tooltips getting cut off (fixes #2) by using bootstrap

### DIFF
--- a/css/achilles.css
+++ b/css/achilles.css
@@ -291,19 +291,19 @@ div.personSummary .row div {
 
 .pathleaf {
 	font-size: 14px;
-	color: #fff;
+	color: #333;
 	font-weight: bold;
 	margin-bottom: 3px;
 }
 .pathleafstat {
 	font-size: 12px;
-	color: #ddd;
+	color: #666;
 	font-family: "Courier New";
 	margin-bottom: 2px;
 }
 .pathstep {
 	font-size: 12px;
-	color: #aaa;
+	color: #333;
 	margin-bottom: 1px;
 }
 hr.path {
@@ -387,4 +387,8 @@ table.dataTable tbody tr.odd.selected {
 }
 .sorting_3 {
 	background-color: rgba(89, 159, 216, 0.1) !important;
+}
+.popover {
+	max-width: 800px;
+	z-index: 1040;
 }

--- a/js/app/reports/condition_era.js
+++ b/js/app/reports/condition_era.js
@@ -242,23 +242,26 @@
 								getcolorvalue: function (node) {
 									return node.length_of_era;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Length of Era: ' + node.length_of_era  + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/condition_occurrence.js
+++ b/js/app/reports/condition_occurrence.js
@@ -244,23 +244,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/drug_era.js
+++ b/js/app/reports/drug_era.js
@@ -240,23 +240,26 @@
 								getcolorvalue: function (node) {
 									return node.length_of_era;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/drug_exposure.js
+++ b/js/app/reports/drug_exposure.js
@@ -256,23 +256,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/observation.js
+++ b/js/app/reports/observation.js
@@ -413,23 +413,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/procedure_occurrence.js
+++ b/js/app/reports/procedure_occurrence.js
@@ -238,23 +238,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/app/reports/visit_occurrence.js
+++ b/js/app/reports/visit_occurrence.js
@@ -237,23 +237,26 @@
 								getcolorvalue: function (node) {
 									return node.records_per_person;
 								},
+								getcontent: function (node) {
+									var result = '',
+										steps = node.path.split('||'),
+										i = steps.length - 1;
+									result += '<div class="pathleaf">' + steps[i] + '</div>';
+									result += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
+									result += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
+									result += '<div class="pathleafstat">Length of Era: ' + format_fixed(node.length_of_era) + '</div>';
+									return result;
+								},
 								gettitle: function (node) {
-									title = '';
-									steps = node.path.split('||');
-									for (i = 0; i < steps.length; i++) {
-										if (i == steps.length - 1) {
-											title += '<hr class="path">';
-											title += '<div class="pathleaf">' + steps[i] + '</div>';
-											title += '<div class="pathleafstat">Prevalence: ' + format_pct(node.pct_persons) + '</div>';
-											title += '<div class="pathleafstat">Number of People: ' + format_comma(node.num_persons) + '</div>';
-											title += '<div class="pathleafstat">Records per Person: ' + format_fixed(node.records_per_person) + '</div>';
-										} else {
-											title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
-										}
+									var title = '',
+										steps = node.path.split('||');
+									for (i = 0; i < steps.length - 1; i++) {
+										title += ' <div class="pathstep">' + Array(i + 1).join('&nbsp;&nbsp') + steps[i] + ' </div>';
 									}
 									return title;
 								}
 							});
+							$('[data-toggle="popover"]').popover();
 						}
 
 					});

--- a/js/modules/d3/jnj.chart.js
+++ b/js/modules/d3/jnj.chart.js
@@ -1659,14 +1659,6 @@
 				.domain([color_range[0], color_range[1]])
 				.range(["#E4FF7A", "#FC7F00"]);
 
-			var tip = d3.tip()
-				.attr('class', 'd3-tip')
-				.offset([-10, 0])
-				.html(function (d) {
-					return options.gettitle(d);
-				})
-			svg.call(tip);
-
 			var cell = svg.selectAll("g")
 				.data(nodes)
 				.enter().append("svg:g")
@@ -1682,17 +1674,23 @@
 				.attr("height", function (d) {
 					return Math.max(0, d.dy - 1);
 				})
-				.attr("title", function (d) {
-					return options.gettitle(d);
-				})
 				.attr("id", function (d) {
 					return d.id;
 				})
 				.style("fill", function (d) {
 					return color(options.getcolorvalue(d));
 				})
-				.on('mouseover', tip.show)
-				.on('mouseout', tip.hide)
+				.attr("data-container", "body")
+				.attr("data-toggle", "popover")
+				.attr("data-trigger", "hover")
+				.attr("data-placement", "top")
+				.attr("data-html", true)
+				.attr("data-title", function (d) {
+					return options.gettitle(d);
+				})
+				.attr("data-content", function (d) {
+					return options.getcontent(d);
+				})
 				.on('click', function (d) {
 					if (d3.event.altKey) {
 						zoom(root);


### PR DESCRIPTION
Please review- should be up to date now. 

I used bootstrap popovers instead of d3-tip to generate tooltips for all treemaps. I had to change some styles to make the text visible and to prevent the nav from overlapping.
