### PR TITLE
documenting deprecated status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**AchillesWeb is now deprecated and no longer supported.**
+
+For full study design tools, please switch to [OHDSI/ATLAS](https://github.com/OHDSI/Atlas). For an approach more consistent with AchillesWeb, try out [OHDSI/ARES](https://github.com/OHDSI/Ares)
+
 AchillesWeb
 ===========
 


### PR DESCRIPTION
This is just a small update to the README to document that AchillesWeb is no longer maintained. I also recommend converting the repository to Archive status. This will convert the repository to read-only, but keep everything available for legacy users.

More detail on archiving here: https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories